### PR TITLE
Feature/fredr tidy return format

### DIFF
--- a/R/fredr_series_observations.R
+++ b/R/fredr_series_observations.R
@@ -99,7 +99,7 @@
 #' \dontrun{
 #' # Observations for "UNRATE" series between 1980 and 2000.  Units are in terms
 #' of change from pervious observation.
-#' fredr_series_observations(
+#' fredr(
 #'   series_id = "UNRATE",
 #'   observation_start = as.Date("1980-01-01"),
 #'   observation_end = as.Date("2000-01-01"),
@@ -108,7 +108,7 @@
 #' # All observations for "OILPRICE" series.  The data is first aggregated by
 #' # quarter by taking the average of all observations in the quarter then
 #' # transformed by taking the natural logarithm.
-#' fredr_series_observations(
+#' fredr(
 #'   series_id = "OILPRICE",
 #'   frequency = "q",
 #'   aggregation_method = "avg",
@@ -155,14 +155,17 @@ fredr_series_observations <- function(series_id = NULL,
 
   frame <- do.call(fredr_request, c(fredr_args, user_args))
 
+  if(NROW(frame) == 0) {
+    return(empty_fredr_tibble())
+  }
+
   frame$value[frame$value == "."] <- NA
 
   obs <- tibble::tibble(
     date = as.Date(frame$date, "%Y-%m-%d"),
+    series_id = series_id,
     value = as.numeric(frame$value)
   )
-
-  names(obs) <- c("date", series_id)
 
   return(obs)
 }
@@ -171,3 +174,19 @@ fredr_series_observations <- function(series_id = NULL,
 #' @export
 fredr <- fredr_series_observations
 
+
+empty_fredr_tibble <- function() {
+
+  zero_length_numeric <- numeric()
+
+  zero_length_date <- zero_length_numeric
+  class(zero_length_date) <- "Date"
+
+  zero_length_character <- character()
+
+  tibble::tibble(
+    date = zero_length_date,
+    series_id = zero_length_character,
+    value = zero_length_numeric
+  )
+}

--- a/R/fredr_series_observations.R
+++ b/R/fredr_series_observations.R
@@ -114,6 +114,24 @@
 #'   aggregation_method = "avg",
 #'   unit = "log"
 #' )
+#'
+#' # To retrieve values for multiple series, use purrr's map_dfr() function.
+#' library(tidyverse)
+#' map_dfr(c("UNRATE", "OILPRICE"), fredr)
+#'
+#' # Using pmap_dfr() allows you to use varying optional parameters as well
+#' params <- list(
+#'   series_id = c("UNRATE", "OILPRICE"),
+#'   frequency = c("m", "q")
+#' )
+#'
+#' pmap_dfr(
+#'   .l = params,
+#'   .f = ~ fredr(series_id = .x, frequency = .y)
+#' )
+#'
+#'
+#'
 #' }
 #' @rdname fredr
 #' @export

--- a/man/fredr.Rd
+++ b/man/fredr.Rd
@@ -133,6 +133,24 @@ fredr(
   aggregation_method = "avg",
   unit = "log"
 )
+
+# To retrieve values for multiple series, use purrr's map_dfr() function.
+library(tidyverse)
+map_dfr(c("UNRATE", "OILPRICE"), fredr)
+
+# Using pmap_dfr() allows you to use varying optional parameters as well
+params <- list(
+  series_id = c("UNRATE", "OILPRICE"),
+  frequency = c("m", "q")
+)
+
+pmap_dfr(
+  .l = params,
+  .f = ~ fredr(series_id = .x, frequency = .y)
+)
+
+
+
 }
 }
 \seealso{

--- a/man/fredr.Rd
+++ b/man/fredr.Rd
@@ -118,7 +118,7 @@ Given a series ID, return observations of that series as a \code{tibble} object.
 \dontrun{
 # Observations for "UNRATE" series between 1980 and 2000.  Units are in terms
 of change from pervious observation.
-fredr_series_observations(
+fredr(
   series_id = "UNRATE",
   observation_start = as.Date("1980-01-01"),
   observation_end = as.Date("2000-01-01"),
@@ -127,7 +127,7 @@ fredr_series_observations(
 # All observations for "OILPRICE" series.  The data is first aggregated by
 # quarter by taking the average of all observations in the quarter then
 # transformed by taking the natural logarithm.
-fredr_series_observations(
+fredr(
   series_id = "OILPRICE",
   frequency = "q",
   aggregation_method = "avg",

--- a/tests/testthat/test_series_observations.R
+++ b/tests/testthat/test_series_observations.R
@@ -6,9 +6,23 @@ test_that("fredr_series_observations() returns proper object", {
   expect_silent(series <- fredr_series_observations(series_id = "GNPCA", limit = 20L))
   expect_s3_class(series, c("tbl_df", "tbl", "data.frame"))
   expect_s3_class(series$date, "Date")
-  expect_type(series[[2]], "double")
-  expect_true(ncol(series) == 2)
+  expect_type(series[[2]], "character")
+  expect_type(series[[3]], "double")
+  expect_true(ncol(series) == 3)
   expect_true(nrow(series) == 20)
+})
+
+test_that("fredr_series_observations() properly returns zero row tibble", {
+  skip_if_no_key()
+  expect_silent(
+    series <- fredr::fredr_series_observations(
+      series_id = "GNPCA",
+      observation_start = as.Date("2050-01-01")
+    )
+  )
+  expect_s3_class(series, c("tbl_df", "tbl", "data.frame"))
+  expect_true(ncol(series) == 3)
+  expect_true(nrow(series) == 0)
 })
 
 test_that("fredr_series_observations() throws errors for bad parameters", {


### PR DESCRIPTION
* `fredr()` now returns a tidy format like we talked about
* Updated tests to reflect this and the next bullet
* `fredr()` now also returns a 0 row tibble with 3 columns named appropriately if no rows are returned from the API. For example:

`fredr("UNRATE", observation_date = as.Date("2019-01-01"))`