### PR TITLE
Update the fredr_set_key() documentation. A few typos. Expand on user…

### DIFF
--- a/R/fredr_set_key.R
+++ b/R/fredr_set_key.R
@@ -1,20 +1,23 @@
 #' Set the FRED API key
 #'
-#' Users of the `fredr`` package must authenticate with the FRED API by use of
+#' Users of the `fredr` package must authenticate with the FRED API by use of
 #' an API key. The function `fredr_set_key()` sets the FRED API key as an
 #' environment variable for use with the service.  For persistence across sessions,
-#' see Details section.
+#' see the Details section.
 #'
 #' @param key A valid FRED API key as a string.  Obtain one at the
 #'				[API Keys](https://api.stlouisfed.org/api_key.html) page.
 #'
 #' @details `fredr_set_key()` sets a key as an environment variable for use with
-#' the `fredr`` package in the current session.  The key can also be set in the
-#' `.Renviron` file in the working directory.  You can edit the file manually by
-#' appending the line `FRED_API_KEY = my_api_ky`, where `my_api_key` is your
-#' actual key.  The function `usethis::edit_r_environ()` does this safely.  Run
-#' `base::readRenviron(".Renviron")` to set the key in the current session; the
-#' variable will be set in subsequent sessions started in the working directory.
+#' the `fredr` package in the current session.  The key can also be set in the
+#' `.Renviron` file at the user or project level scope.  You can edit the file manually by
+#' appending the line `FRED_API_KEY = my_api_key`, where `my_api_key` is your
+#' actual key (remember to not surround the key in quotes).  The function
+#' `usethis::edit_r_environ()` does this safely.  Run
+#' `base::readRenviron(".Renviron")` to set the key in the current session
+#' or restart R for it to take effect. The variable will be set in subsequent
+#' sessions in the working directory if you set it with project level scope,
+#' or everywhere if you set it with user level scope.
 #'
 #' @references See St. Louis Fed Web Services [API Keys](https://api.stlouisfed.org/api_key.html)
 #' to obtain an API key.
@@ -23,7 +26,6 @@
 #'
 #' @examples
 #' \dontrun{
-#' library(fredr)
 #' fredr_set_key("abcdefghijklmnopqrstuvwxyz123456")
 #' }
 #'

--- a/man/fredr_set_key.Rd
+++ b/man/fredr_set_key.Rd
@@ -11,18 +11,25 @@ fredr_set_key(key)
 \href{https://api.stlouisfed.org/api_key.html}{API Keys} page.}
 }
 \description{
-Users of the \code{fredr`` package must authenticate with the FRED API by use of an API key. The function}fredr_set_key()` sets the FRED API key as an
+Users of the \code{fredr} package must authenticate with the FRED API by use of
+an API key. The function \code{fredr_set_key()} sets the FRED API key as an
 environment variable for use with the service.  For persistence across sessions,
-see Details section.
+see the Details section.
 }
 \details{
 \code{fredr_set_key()} sets a key as an environment variable for use with
-the \code{fredr`` package in the current session. The key can also be set in the}.Renviron\code{file in the working directory. You can edit the file manually by appending the line}FRED_API_KEY = my_api_ky\code{, where}my_api_key\code{is your actual key. The function}usethis::edit_r_environ()\code{does this safely. Run}base::readRenviron(".Renviron")` to set the key in the current session; the
-variable will be set in subsequent sessions started in the working directory.
+the \code{fredr} package in the current session.  The key can also be set in the
+\code{.Renviron} file at the user or project level scope.  You can edit the file manually by
+appending the line \code{FRED_API_KEY = my_api_key}, where \code{my_api_key} is your
+actual key (remember to not surround the key in quotes).  The function
+\code{usethis::edit_r_environ()} does this safely.  Run
+\code{base::readRenviron(".Renviron")} to set the key in the current session
+or restart R for it to take effect. The variable will be set in subsequent
+sessions in the working directory if you set it with project level scope,
+or everywhere if you set it with user level scope.
 }
 \examples{
 \dontrun{
-library(fredr)
 fredr_set_key("abcdefghijklmnopqrstuvwxyz123456")
 }
 


### PR DESCRIPTION
… vs project level scoping for .Renviron

Just a bit of documentation cleaning for `fredr_set_key()`