### PR TITLE
Preemptive CRAN comments for reasoning for \dontrun{}

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,18 @@
+## Release Summary
+
+This is the first release of 'fredr'. 'fredr' provides a complete R interface
+to the FRED (Federal Reserve of Economic Data, St. Louis) API.
+
+Notes to CRAN: We understand that generally examples should not be wrapped in
+\dontrun{}. However, all examples wrapped in \dontrun{} require API
+authentication and would fail on CRAN. We test extensively on Travis and 
+Appveyor. The 'riingo' package does a similar thing, and its author is a
+co-author here.
+
+https://github.com/sboysel/fredr/tree/master/tests/testthat
+https://travis-ci.org/sboysel/fredr
+https://ci.appveyor.com/project/sboysel/fredr/branch/master
+
 ## Test environments
 * local OS X install, R 3.5.1
 * ubuntu 12.04 (on travis-ci), R 3.5.1


### PR DESCRIPTION
These are my suggestions of what to say to CRAN the first time around. They are pretty nice (and super helpful sometimes), but sticklers for the rules. Hopefully this will help them understand our reasoning for the `\dontrun{}` blocks.