### PR TITLE
Parse and return `realtime_start` and `realtime_end` columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # fredr (development version)
 
-# fredr 2.0.1
-
-## Bugfix
+* `fredr()` / `fredr_series_observations()` now always return `realtime_start`
+  and `realtime_end` columns. These are useful when setting the
+  `realtime_start` / `realtime_end` arguments, or when using the `vintage_dates`
+  argument (#88).
 
 * Fixed a bug in `fredr()` / `fredr_series_observations()` so that now the 
   `vintage_dates` argument properly accepts a `Date` vector of length 1 or

--- a/R/fredr_series_observations.R
+++ b/R/fredr_series_observations.R
@@ -184,11 +184,18 @@ fredr_series_observations <- function(series_id,
   }
 
   frame$value[frame$value == "."] <- NA
+  frame$value <- as.numeric(frame$value)
+
+  frame$date <- as.Date(frame$date, format = "%Y-%m-%d")
+  frame$realtime_start <- as.Date(frame$realtime_start, format = "%Y-%m-%d")
+  frame$realtime_end <- as.Date(frame$realtime_end, format = "%Y-%m-%d")
 
   obs <- tibble::tibble(
-    date = as.Date(frame$date, "%Y-%m-%d"),
+    date = frame$date,
     series_id = series_id,
-    value = as.numeric(frame$value)
+    value = frame$value,
+    realtime_start = frame$realtime_start,
+    realtime_end = frame$realtime_end
   )
 
   obs
@@ -211,6 +218,8 @@ empty_fredr_tibble <- function() {
   tibble::tibble(
     date = zero_length_date,
     series_id = zero_length_character,
-    value = zero_length_numeric
+    value = zero_length_numeric,
+    realtime_start = zero_length_date,
+    realtime_end = zero_length_date
   )
 }


### PR DESCRIPTION
Part of #88 and #89

We now always return `realtime_start` and `realtime_end` columns in `fredr_series_observations()`

``` r
library(fredr)

# we now know how to differentiate the duplicate dates based on realtime_*
fredr_series_observations(
  series_id = "GDPC1",
  observation_start = as.Date("2000-01-01"),
  vintage_dates = as.Date(c("2001-01-01", "2002-01-01"))
)
#> # A tibble: 10 x 5
#>    date       series_id value realtime_start realtime_end
#>    <date>     <chr>     <dbl> <date>         <date>      
#>  1 2000-01-01 GDPC1     9192. 2001-01-01     2001-07-26  
#>  2 2000-01-01 GDPC1     9102. 2001-07-27     2002-01-01  
#>  3 2000-04-01 GDPC1     9319. 2001-01-01     2001-07-26  
#>  4 2000-04-01 GDPC1     9229. 2001-07-27     2002-01-01  
#>  5 2000-07-01 GDPC1     9370. 2001-01-01     2001-07-26  
#>  6 2000-07-01 GDPC1     9260. 2001-07-27     2002-01-01  
#>  7 2000-10-01 GDPC1     9304. 2001-07-27     2002-01-01  
#>  8 2001-01-01 GDPC1     9334. 2001-07-27     2002-01-01  
#>  9 2001-04-01 GDPC1     9342. 2001-09-28     2002-01-01  
#> 10 2001-07-01 GDPC1     9310. 2001-12-21     2002-01-01

# for consistency, we always return the realtime_start/end columns.
# they are set to the current date if not specified
fredr_series_observations(
  series_id = "GDPC1",
  observation_start = as.Date("2000-01-01")
)
#> # A tibble: 83 x 5
#>    date       series_id  value realtime_start realtime_end
#>    <date>     <chr>      <dbl> <date>         <date>      
#>  1 2000-01-01 GDPC1     12924. 2021-01-12     2021-01-12  
#>  2 2000-04-01 GDPC1     13161. 2021-01-12     2021-01-12  
#>  3 2000-07-01 GDPC1     13178. 2021-01-12     2021-01-12  
#>  4 2000-10-01 GDPC1     13261. 2021-01-12     2021-01-12  
#>  5 2001-01-01 GDPC1     13223. 2021-01-12     2021-01-12  
#>  6 2001-04-01 GDPC1     13300. 2021-01-12     2021-01-12  
#>  7 2001-07-01 GDPC1     13245. 2021-01-12     2021-01-12  
#>  8 2001-10-01 GDPC1     13281. 2021-01-12     2021-01-12  
#>  9 2002-01-01 GDPC1     13397. 2021-01-12     2021-01-12  
#> 10 2002-04-01 GDPC1     13478. 2021-01-12     2021-01-12  
#> # … with 73 more rows
```

<sup>Created on 2021-01-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>