### PR TITLE
Fix error message being blank

### DIFF
--- a/R/fredr_request.R
+++ b/R/fredr_request.R
@@ -70,8 +70,7 @@ fredr_request <- function(endpoint,
   }
 
   if (resp$status_code != 200) {
-    err <- httr::content(resp)
-    abort(paste0(err$error_code, ": ", err$error_message))
+    abort(httr::http_status(resp))
   }
 
   if (!to_frame) {


### PR DESCRIPTION
Right now `httr::content(resp)` doesn't return a vector, so trying to access the `error_code` and `error_message` columns from `err` doesn't do anything and gives an empty error message. Using `httr::http_status(resp)` works quite neatly, showing both the status code and error message correctly.