### PR TITLE
Improve error handling on unknown error formats

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fredr (development version)
 
+* Improved error handling when the response has an unknown error format (#96).
+
 # fredr 2.1.0
 
 * `fredr()` / `fredr_series_observations()` now always return `realtime_start`

--- a/R/fredr_request.R
+++ b/R/fredr_request.R
@@ -241,8 +241,9 @@ validate_status <- function(response) {
     message <- paste0(error_code, ": ", error_message)
   } else {
     # Completely unexpected error format.
-    # Do the best we can by at least passing the info through.
-    message <- paste(as.character(content), sep = " ")
+    # Do the best we can with `http_status()`.
+    status <- httr::http_status(response)
+    message <- status$message
   }
 
   abort(message)

--- a/R/fredr_request.R
+++ b/R/fredr_request.R
@@ -226,7 +226,21 @@ fredr_termination_codes <- function() {
 }
 
 validate_status <- function(response) {
+  type <- httr::http_type(response)
+
+  if (!identical(type, "application/json")) {
+    # Something went wrong before we could even request a JSON response.
+    # The returned response is likely XML, but we don't guess, and instead
+    # extract a basic error message with `http_status()`.
+    # This can happen when the FRED API is completely down, where we
+    # can get a 500 error and an XML reponse.
+    status <- httr::http_status(response)
+    message <- status$message
+    abort(message)
+  }
+
   if (response$status_code == 200) {
+    # All good
     return(invisible(response))
   }
 
@@ -236,15 +250,16 @@ validate_status <- function(response) {
   error_code <- content$error_code
   error_message <- content$error_message
 
-  if (!is_null(error_code) && !is_null(error_message)) {
-    # Known error format
-    message <- paste0(error_code, ": ", error_message)
-  } else {
-    # Completely unexpected error format.
+  if (is_null(error_code) || is_null(error_message)) {
+    # Completely unexpected JSON error format.
     # Do the best we can with `http_status()`.
     status <- httr::http_status(response)
     message <- status$message
+    abort(message)
   }
+
+  # Known error format
+  message <- paste0(error_code, ": ", error_message)
 
   abort(message)
 }


### PR DESCRIPTION
Closes #96 
Closes #97 

@sboysel this is probably the best we can do. The error information was coming back in a non-standard format. This _should_ now at least return that non-standard information in a character string, even if it isn't very pretty.

If there is no `error_code` or `error_message`, we do the best we can by at least returning what was in the response content, pasted together as a character string.

This also explicitly uses `httr::content(response, "text")` for the bad response now, which is more robust than letting httr auto pick how to handle it. That may have also been part of the problem.

Pretty hard to test this out, as I can't make the FRED api fail with a 500 error on demand, but that is okay

